### PR TITLE
Add Job and Ping schema with scaffolding

### DIFF
--- a/lib/uppy/job/loader.ex
+++ b/lib/uppy/job/loader.ex
@@ -1,0 +1,2 @@
+defmodule Uppy.Job.Loader do
+end

--- a/lib/uppy/job/schema.ex
+++ b/lib/uppy/job/schema.ex
@@ -1,0 +1,16 @@
+defmodule Uppy.Job do
+  use Ecto.Schema
+
+  alias Uppy.Ping
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "jobs" do
+    field :url, :string
+
+    has_many :pings, Ping
+
+    timestamps()
+  end
+end

--- a/lib/uppy/job/use_case.ex
+++ b/lib/uppy/job/use_case.ex
@@ -1,0 +1,23 @@
+defmodule Uppy.Job.UseCase do
+  import Ecto.Changeset
+
+  alias Uppy.{Repo, Job}
+
+  @required_fields ~w(url)a
+  @url_format ~r'^http(?:s)?://\S+\.\S+$'i
+
+  def create(params \\ %{}) do
+    %Job{}
+    |> changeset(params)
+    |> Repo.insert()
+  end
+
+  ###
+
+  defp changeset(schema, params) do
+    schema
+    |> cast(params, @required_fields)
+    |> validate_required(@required_fields)
+    |> validate_format(:url, @url_format)
+  end
+end

--- a/lib/uppy/ping/loader.ex
+++ b/lib/uppy/ping/loader.ex
@@ -1,0 +1,2 @@
+defmodule Uppy.Ping.Loader do
+end

--- a/lib/uppy/ping/schema.ex
+++ b/lib/uppy/ping/schema.ex
@@ -1,0 +1,17 @@
+defmodule Uppy.Ping do
+  use Ecto.Schema
+
+  alias Uppy.Job
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "pings" do
+    field :status_code, :integer
+    field :time, :integer
+
+    belongs_to :job, Job
+
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/uppy/ping/use_case.ex
+++ b/lib/uppy/ping/use_case.ex
@@ -1,0 +1,37 @@
+defmodule Uppy.Ping.UseCase do
+  import Ecto.Changeset
+
+  alias Uppy.{Repo, Job, Ping}
+
+  @required_fields ~w(status_code time job_id)a
+
+  def create(job, params \\ %{})
+
+  def create(%Job{} = job, params) do
+    %Ping{}
+    |> changeset(job, params)
+    |> Repo.insert()
+  end
+
+  def create(_job, _params), do: {:error, :job_required}
+
+  ###
+
+  defp changeset(schema, %{id: job_id} = _job, params) do
+    schema
+    |> cast(params, @required_fields)
+    |> change(job_id: job_id)
+    |> validate_required(@required_fields)
+    |> validate_status_code()
+  end
+
+  defp validate_status_code(changeset) do
+    validate_change(changeset, :status_code, fn :status_code, status_code ->
+      if status_code < 100 or status_code >= 600 do
+        [status_code: "invalid status code"]
+      else
+        []
+      end
+    end)
+  end
+end

--- a/priv/repo/migrations/20230312191250_add_jobs.exs
+++ b/priv/repo/migrations/20230312191250_add_jobs.exs
@@ -1,0 +1,12 @@
+defmodule Uppy.Repo.Migrations.AddJobs do
+  use Ecto.Migration
+
+  def change do
+    create table(:jobs, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :url, :string
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20230312192227_add_pings.exs
+++ b/priv/repo/migrations/20230312192227_add_pings.exs
@@ -1,0 +1,15 @@
+defmodule Uppy.Repo.Migrations.AddPings do
+  use Ecto.Migration
+
+  def change do
+    create table(:pings, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :status_code, :integer
+      add :time, :integer
+
+      add(:job_id, references(:jobs, type: :uuid), null: false)
+
+      timestamps(updated_at: false)
+    end
+  end
+end

--- a/test/uppy/job/use_case_test.exs
+++ b/test/uppy/job/use_case_test.exs
@@ -1,0 +1,39 @@
+defmodule Uppy.Job.UseCaseTest do
+  use ExUnit.Case, async: true
+
+  alias Uppy.{Repo, Job.UseCase}
+
+  describe "create/1" do
+    setup do
+      :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    end
+
+    test "creates a new job" do
+      params = %{
+        "url" => "https://example.org"
+      }
+
+      assert {:ok, job} = UseCase.create(params)
+
+      assert job.url == "https://example.org"
+    end
+
+    test "returns an error with missing fields" do
+      params = %{}
+
+      assert {:error, %{errors: errors}} = UseCase.create(params)
+
+      assert {:url, {"can't be blank", [validation: :required]}} in errors
+    end
+
+    test "returns an error when an invalid URL is provided" do
+      params = %{
+        "url" => "not-a-url"
+      }
+
+      assert {:error, %{errors: errors}} = UseCase.create(params)
+
+      assert {:url, {"has invalid format", [validation: :format]}} in errors
+    end
+  end
+end

--- a/test/uppy/ping/use_case_test.exs
+++ b/test/uppy/ping/use_case_test.exs
@@ -1,0 +1,55 @@
+defmodule Uppy.Ping.UseCaseTest do
+  use ExUnit.Case, async: true
+
+  alias Uppy.{Repo, Job, Ping.UseCase}
+
+  describe "create/1" do
+    setup do
+      :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+      job = %Job{id: Ecto.UUID.generate()} |> Repo.insert!()
+
+      {:ok, job: job}
+    end
+
+    test "creates a new ping", %{job: job} do
+      params = %{
+        "status_code" => 200,
+        "time" => 20
+      }
+
+      assert {:ok, ping} = UseCase.create(job, params)
+
+      assert ping.time == 20
+      assert ping.status_code == 200
+      assert ping.job_id == job.id
+      assert ping.inserted_at
+    end
+
+    test "returns an error with missing fields", %{job: job} do
+      params = %{}
+
+      assert {:error, %{errors: errors}} = UseCase.create(job, params)
+
+      assert {:status_code, {"can't be blank", [validation: :required]}} in errors
+      assert {:time, {"can't be blank", [validation: :required]}} in errors
+    end
+
+    test "returns an error when job is not passed" do
+      params = %{}
+
+      assert {:error, :job_required} = UseCase.create(nil, params)
+    end
+
+    test "returns an error when saving an incorrect status code", %{job: job} do
+      params = %{
+        "status_code" => 10,
+        "time" => 10
+      }
+
+      assert {:error, %{errors: errors}} = UseCase.create(job, params)
+
+      assert {:status_code, {"invalid status code", []}} in errors
+    end
+  end
+end


### PR DESCRIPTION
Here we add basic schemas.

## Job

This schema will contain the URL that we will check. For now I think we should go with the fixed interval, and later introduce variable intervals.

## Ping

This is one "run" of the Job. We store the complete response and the time it took us to get the said response.

## Code architecture

We have three basic components:

- `schema.ex` -> where we store the schema of the module
- `use_case.ex` -> where we have the business logic related to the module
- `loader.ex` -> where we store all SQL queries to get the said schema